### PR TITLE
Update runtime to 3.32

### DIFF
--- a/com.vinszent.GnomeTwitch.json
+++ b/com.vinszent.GnomeTwitch.json
@@ -22,12 +22,31 @@
   ],
   "modules": [
     {
+      "name": "ffmpeg",
+      "cleanup": [ "/include", "/lib/pkgconfig", "/share/ffmpeg/examples" ],
+      "config-opts": [
+        "--enable-shared",
+        "--disable-static",
+        "--enable-gnutls",
+        "--disable-doc",
+        "--disable-programs",
+        "--disable-encoders",
+        "--disable-muxers",
+        "--enable-encoder=png"
+      ],
+      "sources": [{
+        "type": "archive",
+        "url": "https://ffmpeg.org/releases/ffmpeg-3.4.5.tar.xz",
+        "sha256": "741cbd6394eaed370774ca4cc089eaafbc54d0824b9aa360d4b3b0cbcbc4a92c"
+      }]
+    },
+    {
       "name": "gst-libav",
       "buildsystem": "meson",
       "sources": [{
         "type": "archive",
-        "url": "https://gstreamer.freedesktop.org/src/gst-libav/gst-libav-1.14.2.tar.xz",
-        "sha256": "8a351c39c5cfc2bbd31ca434ec4a290a730a26efbdea962fdd8306dce5c576de"
+        "url": "https://gstreamer.freedesktop.org/src/gst-libav/gst-libav-1.14.4.tar.xz",
+        "sha256": "dfd78591901df7853eab7e56a86c34a1b03635da0d3d56b89aa577f1897865da"
       }]
     },
     {

--- a/com.vinszent.GnomeTwitch.json
+++ b/com.vinszent.GnomeTwitch.json
@@ -20,35 +20,19 @@
     "--filesystem=~/.config/dconf:ro",
     "--talk-name=ca.desrt.dconf"
   ],
+  "add-extensions": {
+    "org.freedesktop.Platform.ffmpeg-full": {
+        "directory": "lib/ffmpeg",
+        "add-ld-path": ".",
+        "version": "19.08",
+        "autodownload": true,
+        "autodelete": false
+    }
+  },
+  "cleanup-commands": [
+    "mkdir -p ${FLATPAK_DEST}/lib/ffmpeg"
+  ],
   "modules": [
-    {
-      "name": "ffmpeg",
-      "cleanup": [ "/include", "/lib/pkgconfig", "/share/ffmpeg/examples" ],
-      "config-opts": [
-        "--enable-shared",
-        "--disable-static",
-        "--enable-gnutls",
-        "--disable-doc",
-        "--disable-programs",
-        "--disable-encoders",
-        "--disable-muxers",
-        "--enable-encoder=png"
-      ],
-      "sources": [{
-        "type": "archive",
-        "url": "https://ffmpeg.org/releases/ffmpeg-3.4.5.tar.xz",
-        "sha256": "741cbd6394eaed370774ca4cc089eaafbc54d0824b9aa360d4b3b0cbcbc4a92c"
-      }]
-    },
-    {
-      "name": "gst-libav",
-      "buildsystem": "meson",
-      "sources": [{
-        "type": "archive",
-        "url": "https://gstreamer.freedesktop.org/src/gst-libav/gst-libav-1.14.4.tar.xz",
-        "sha256": "dfd78591901df7853eab7e56a86c34a1b03635da0d3d56b89aa577f1897865da"
-      }]
-    },
     {
       "name": "gnome-twitch",
       "buildsystem": "meson",

--- a/com.vinszent.GnomeTwitch.json
+++ b/com.vinszent.GnomeTwitch.json
@@ -2,7 +2,7 @@
   "app-id": "com.vinszent.GnomeTwitch",
   "branch": "stable",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "3.32",
+  "runtime-version": "3.34",
   "sdk": "org.gnome.Sdk",
   "command": "gnome-twitch",
   "finish-args": [
@@ -67,13 +67,13 @@
       "modules": [
         {
           "name": "libpeas",
-          "config-opts": [ "--disable-gtk-doc", "--disable-python2", "--disable-python3" ],
+          "buildsystem": "meson",
           "cleanup": [ "/bin/*", "/lib/peas-demo", "/include", "/lib/girepository-1.0",
                        "/lib/*.la", "/lib/pkgconfig", "/share/gir-1.0", "/share/gtk-doc" ],
           "sources": [{
             "type": "archive",
-            "url": "https://download.gnome.org/sources/libpeas/1.22/libpeas-1.22.0.tar.xz",
-            "sha256": "5b2fc0f53962b25bca131a5ec0139e6fef8e254481b6e777975f7a1d2702a962"
+            "url": "https://download.gnome.org/sources/libpeas/1.24/libpeas-1.24.0.tar.xz",
+            "sha256": "0b9a00138c129a663de3eef5569b00ace03ce31d345f7af783768e9f35c8e6f9"
           }]
         }
       ]

--- a/com.vinszent.GnomeTwitch.json
+++ b/com.vinszent.GnomeTwitch.json
@@ -1,6 +1,5 @@
 {
   "app-id": "com.vinszent.GnomeTwitch",
-  "branch": "stable",
   "runtime": "org.gnome.Platform",
   "runtime-version": "3.34",
   "sdk": "org.gnome.Sdk",

--- a/com.vinszent.GnomeTwitch.json
+++ b/com.vinszent.GnomeTwitch.json
@@ -2,7 +2,7 @@
   "app-id": "com.vinszent.GnomeTwitch",
   "branch": "stable",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "3.30",
+  "runtime-version": "3.32",
   "sdk": "org.gnome.Sdk",
   "command": "gnome-twitch",
   "finish-args": [

--- a/com.vinszent.GnomeTwitch.json
+++ b/com.vinszent.GnomeTwitch.json
@@ -2,7 +2,7 @@
   "app-id": "com.vinszent.GnomeTwitch",
   "branch": "stable",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "3.28",
+  "runtime-version": "3.30",
   "sdk": "org.gnome.Sdk",
   "command": "gnome-twitch",
   "finish-args": [


### PR DESCRIPTION
Current gst-libav doesn't build with runtime-provided ffmpeg 4.x, so bundle 3.x.