### PR TITLE
EOL due to the application being unusable in its current state

### DIFF
--- a/com.vinszent.GnomeTwitch.json
+++ b/com.vinszent.GnomeTwitch.json
@@ -1,7 +1,7 @@
 {
   "app-id": "com.vinszent.GnomeTwitch",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "3.34",
+  "runtime-version": "3.38",
   "sdk": "org.gnome.Sdk",
   "command": "gnome-twitch",
   "finish-args": [

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "end-of-life": "This application is no longer maintained because Twitch.tv updated their API and the application doesn't support it."
+}


### PR DESCRIPTION
It's been a long time now and upstream is MIA. We shouldn't be shipping this anymore.